### PR TITLE
repair voting system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Regulamin Serwera „Gandalf”
 
-  
+
 
 ## §1 Założenia wstępne
 
-  
+
 1. Każdy członek serwera „Gandalf” (dalej **Serwer**) znajdującego się na platformie Discord jest zobowiązany do przestrzegania niniejszego Regulaminu Serwera „Gandalf” (dalej **Regulamin**).
 
 2.  Najnowsza wersja **regulaminu** zawsze będzie dostępna [tutaj](https://github.com/marximimus/regulamin-gandalfa/blob/main/README.md).
@@ -20,15 +20,15 @@
 ## §2 Role członków serwera
 
 1.  Moderatorzy to grupa zamknięta. Nikt nie może stracić roli Moderatora (na dłużej niż 10 minut), poza przypadkiem, w którym prawie wszyscy (co najwyżej jeden może zgłosić sprzeciw) Moderatorzy, wykluczając osobę, której zamierza się odebrać rolę, zgadzają się o usunięciu roli od danej osoby.
-2.  Aby zostać Moderatorem należy złożyć wniosek do Właściciela Serwera. Właściciel ma wtedy obowiązek przeprowadzić głosowanie wśród Moderatorów. Głosowanie trwa do momentu, aż wszyscy uprawnieni oddadzą głos lub gdy minie 16 godzin od rozpoczęcia głosowania. Moderatorzy mają 3 opcje głosu: zezwolenie na dodanie roli Moderatora danej osobie, odrzucenie lub wstrzymanie się od głosu. Moderatorzy mogą oddać jeden głos w czasie głosowania. Nie dotyczy to właściciela serwera, który ma uprawnienie do oddania dwóch głosów. Jeśli oddanych zostanie 70% możliwych głosów, z których co najmniej 60% nie będzie negatywnych, rola Moderatora zostanie przyznana.
+2.  Aby zostać Moderatorem należy złożyć wniosek do Właściciela Serwera. Właściciel ma wtedy obowiązek przeprowadzić głosowanie wśród Moderatorów. Głosowanie trwa do momentu, aż wszyscy uprawnieni oddadzą głos lub gdy minie 16 godzin od rozpoczęcia głosowania. Moderatorzy mają 3 opcje głosu: zezwolenie na dodanie roli Moderatora danej osobie, odrzucenie lub wstrzymanie się od głosu. Moderatorzy mogą oddać jeden głos w czasie głosowania. Nie dotyczy to właściciela serwera, który ma uprawnienie do oddania dwóch głosów. Jeśli oddanych zostanie co najmniej 65% możliwych głosów, a co najmniej połowa pozostałych nie będzie wstrzymaniem się od głosu oraz ponad 50% głosów decydujących (za lub przeciw) będzie pozytywnych, rola Moderatora zostanie przyznana.
 3.  Moderatorzy mają prawo wprowadzać zmiany w Regulaminie. Na wniosek jednego z nich następuje głosowanie wśród Moderatorów i Starostów.
-4.  W trakcie głosowania na zmianę Regulaminu Serwera, każdy Moderator i Starosta może oddać jeden głos: zezwolenie, odrzucenie lub wstrzymanie się od głosu. Głosowanie trwa do momentu, aż wszyscy uprawnieni oddadzą głos lub gdy minie 16 godzin od rozpoczęcia głosowania. Jeśli co najmniej 70% sposród uprawnionych odda co najmniej 60% pozytywnych głosów, Właściciel Serwera ma obowiązek dodać/zmienić/usunąć przegłosowany punkt w regulaminie. 
+4.  W trakcie głosowania na zmianę Regulaminu Serwera, każdy Moderator i Starosta może oddać jeden głos: zezwolenie, odrzucenie lub wstrzymanie się od głosu. Głosowanie trwa do momentu, aż wszyscy uprawnieni oddadzą głos lub gdy minie 16 godzin od rozpoczęcia głosowania. Jeśli zagłosuje co najmniej 65% sposród uprawnionych, co najmniej połowa z głosujących odda decydujący głos (za lub przeciw) i ponad 50% decydujących głosów będzie pozytywnych, Właściciel Serwera ma obowiązek dodać/zmienić/usunąć przegłosowany punkt w regulaminie. 
 5.  Rola Moderatora uprawnia do Zarządzania Wiadomościami, Zarządzania Kanałami, Zarządzania Pseudonimami, Otwierania Dziennika Zdarzeń, Zarządzania Rolami i wszystkich uprawnień ról niższych.
 5.  Starosta i Honorowy Obywatel są rolami nadawanymi przez Właściciela Serwera. Ich uzyskanie zależy tylko i wyłącznie od Jego upodobań.
 6.  Każdy członek Serwera „Gandalf” powinien otrzymać rolę Obywatel. Jeśli takowa nie została mu przyznana, powinien zgłosić się do Własciciela Serwera lub jednego z Moderatorów.
 
 ## §3 Zasady obowiązujące na Serwerze
-  
+
 1. Nie należy edytować jednej wiadomości więcej niż 5 razy w ciągu jednego dnia.
 
-2. Nie spamujemy na kanałach innych niż #findusbot. Spamowaniem nazywamy wysłanie więcej niż 3 wiadomości w ciągu 2 sekund. 
+2. Nie spamujemy na kanałach innych niż #findusbot. Spamowaniem nazywamy wysłanie więcej niż 3 wiadomości w ciągu 2 sekund.


### PR DESCRIPTION
There were 3 major changes:
 - a word "at least 70%" was lacking, indicating that exactly 70% of 6 moderators have to vote for yes (or less, if less willl vote; despite that it is impossible to make a new moderator)
 - abstaining was the same as voting for no, this has been fixed
 - some percentage changes